### PR TITLE
Adding basic docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14
+
+WORKDIR "/app"
+
+RUN git clone https://github.com/mawrkus/docker .git . \
+    && yarn install
+
+ENTRYPOINT ["node", "bin/joey-the-differ.js"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ npm install joey-the-differ
 
 ## 🧬 Usage
 
+### Command-line
+`docker run joey-the-differ --help`
+
+### Library
 ```js
 import JoeyTheDiffer from 'joey-the-differ';
 


### PR DESCRIPTION
This is a basic docker image to be able to use the tool as a command-line from anywhere with Docker.

It would be good to link the releases with dockerHub to autobuild images.